### PR TITLE
Add logging capabilities

### DIFF
--- a/fabric/src/main/java/dev/birb/wgpu/rust/WgpuNative.java
+++ b/fabric/src/main/java/dev/birb/wgpu/rust/WgpuNative.java
@@ -76,8 +76,6 @@ public class WgpuNative {
 
     public static native String getBackend();
 
-    public static native HashMap<String, Integer> bakeBlockModels();
-
     public static native void setWorldRenderState(boolean render);
 
     public static native void texImage2D(int textureId, int target, int level, int internalFormat, int width, int height, int border, int format, int _type, long pixels_ptr);
@@ -115,8 +113,6 @@ public class WgpuNative {
     public static native void runHelperThread();
 
     public static native String getVideoMode();
-
-    public static native void scheduleChunkRebuild(int x, int z);
 
     public static native long createPalette(long idList);
 

--- a/rust/wgpu-mc-jni/Cargo.toml
+++ b/rust/wgpu-mc-jni/Cargo.toml
@@ -34,6 +34,8 @@ get-size = { version = "0.1.1" }
 tracing = "0.1.31"
 tracing-timing = "0.6.0"
 slab = "0.4.7"
+log = "0.4.17"
+env_logger = "0.10.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust/wgpu-mc-jni/src/pia.rs
+++ b/rust/wgpu-mc-jni/src/pia.rs
@@ -51,9 +51,6 @@ impl PackedIntegerArray {
     pub fn compute_storage_index(&self, index: i32) -> i32 {
         let l = self.index_scale as u32 as i64;
         let m = self.index_offset as u32 as i64;
-
-        // println!("l {} m {} idxs {}", l, m, self.index_shift);
-
         (((((index as i64) * l) + m) >> 32) >> self.index_shift) as i32
     }
 }

--- a/rust/wgpu-mc-jni/src/renderer.rs
+++ b/rust/wgpu-mc-jni/src/renderer.rs
@@ -46,7 +46,7 @@ pub fn start_rendering(env: JNIEnv, title: JString) {
             .unwrap(),
     );
 
-    println!("Opened window");
+    log::info!("Opened window");
 
     WINDOW.set(window.clone()).unwrap();
 
@@ -76,7 +76,7 @@ pub fn start_rendering(env: JNIEnv, title: JString) {
 
     let mut current_modifiers = ModifiersState::empty();
 
-    println!("Starting event loop");
+    log::trace!("Starting event loop");
 
     let wm_clone = wm.clone();
     let wm_clone_1 = wm.clone();

--- a/rust/wgpu-mc-jni/src/settings.rs
+++ b/rust/wgpu-mc-jni/src/settings.rs
@@ -68,7 +68,7 @@ impl Settings {
             default.write();
             default
         };
-        println!("Loaded settings: {setting:?}");
+        log::info!("Loaded settings: {setting:?}");
         setting
     }
 

--- a/rust/wgpu-mc/Cargo.toml
+++ b/rust/wgpu-mc/Cargo.toml
@@ -32,3 +32,5 @@ serde_with = "2.1.0"
 web-sys = "0.3.53"
 minecraft-assets = { git = "https://github.com/wgpu-mc/minecraft-assets.git" }
 get-size = { version = "0.1.1", features = ["derive"] }
+log = "0.4.17"
+env_logger = "0.10.0"

--- a/rust/wgpu-mc/Cargo.toml
+++ b/rust/wgpu-mc/Cargo.toml
@@ -33,4 +33,3 @@ web-sys = "0.3.53"
 minecraft-assets = { git = "https://github.com/wgpu-mc/minecraft-assets.git" }
 get-size = { version = "0.1.1", features = ["derive"] }
 log = "0.4.17"
-env_logger = "0.10.0"

--- a/rust/wgpu-mc/Cargo.toml
+++ b/rust/wgpu-mc/Cargo.toml
@@ -33,3 +33,4 @@ web-sys = "0.3.53"
 minecraft-assets = { git = "https://github.com/wgpu-mc/minecraft-assets.git" }
 get-size = { version = "0.1.1", features = ["derive"] }
 log = "0.4.17"
+logging_timer = "1.1.0"

--- a/rust/wgpu-mc/src/lib.rs
+++ b/rust/wgpu-mc/src/lib.rs
@@ -107,6 +107,8 @@ impl WmRenderer {
         window: &W,
         vsync: bool,
     ) -> WgpuState {
+        env_logger::init();
+
         let size = window.get_window_size();
 
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);

--- a/rust/wgpu-mc/src/lib.rs
+++ b/rust/wgpu-mc/src/lib.rs
@@ -107,8 +107,6 @@ impl WmRenderer {
         window: &W,
         vsync: bool,
     ) -> WgpuState {
-        env_logger::init();
-
         let size = window.get_window_size();
 
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);


### PR DESCRIPTION
This PR adds 2 dependencies: [`log`](https://crates.io/crates/log) and [`env_logger`](https://crates.io/crates/env_logger), which are the crates used by wgpu to log.
Adding these can make debugging way easier, giving optional access to debug logs via the `RUST_LOG` environment variable.