### PR TITLE
"""fix""" nan polluting 2d rendering projection matrices

### DIFF
--- a/fabric/src/main/java/dev/birb/wgpu/mixin/render/WindowMixin.java
+++ b/fabric/src/main/java/dev/birb/wgpu/mixin/render/WindowMixin.java
@@ -37,12 +37,6 @@ public class WindowMixin {
 
     }
 
-    @Inject(method = "calculateScaleFactor", at = @At("RETURN")/*,cancellable = true*/)
-    public void calculateScaleFactor(int guiScale, boolean forceUnicodeFont, CallbackInfoReturnable<Integer> cir) {
-        //this causes a div/0 error **sometimes????**
-        //cir.setReturnValue(guiScale);
-    }
-
     /**
      * @author wgpu-mc
      */

--- a/fabric/src/main/java/dev/birb/wgpu/mixin/render/WindowMixin.java
+++ b/fabric/src/main/java/dev/birb/wgpu/mixin/render/WindowMixin.java
@@ -37,9 +37,10 @@ public class WindowMixin {
 
     }
 
-    @Inject(method = "calculateScaleFactor", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "calculateScaleFactor", at = @At("RETURN")/*,cancellable = true*/)
     public void calculateScaleFactor(int guiScale, boolean forceUnicodeFont, CallbackInfoReturnable<Integer> cir) {
-        cir.setReturnValue(guiScale);
+        //this causes a div/0 error **sometimes????**
+        //cir.setReturnValue(guiScale);
     }
 
     /**


### PR DESCRIPTION
Birb overrode Window.calculateScaleFactor() and caused division by zero to happen on some platforms. This pr reverts to using the vanilla method, which works fine