### PR TITLE
Fix segfault as a result of improper memory management of pointers.

### DIFF
--- a/fabric/src/main/java/dev/birb/wgpu/mixin/core/GlStateManagerMixin.java
+++ b/fabric/src/main/java/dev/birb/wgpu/mixin/core/GlStateManagerMixin.java
@@ -16,7 +16,6 @@ import org.spongepowered.asm.mixin.Overwrite;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("OverwriteAuthorRequired")

--- a/fabric/src/main/java/dev/birb/wgpu/mixin/core/GlStateManagerMixin.java
+++ b/fabric/src/main/java/dev/birb/wgpu/mixin/core/GlStateManagerMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.util.math.Matrix4f;
 import net.minecraft.util.math.Vec3f;
 import net.minecraft.util.math.Vector4f;
 import org.jetbrains.annotations.Nullable;
+import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.system.MemoryUtil;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +16,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.Arrays;
 import java.util.List;
 
 @SuppressWarnings("OverwriteAuthorRequired")
@@ -499,7 +501,11 @@ public class GlStateManagerMixin {
     @Overwrite(remap = false)
     public static void _texSubImage2D(int target, int level, int offsetX, int offsetY, int width, int height, int format, int type, long pixels) {
         //we do not care about mip maps
-        if(level != 0) return;
+        if(level != 0) 
+            return;
+
+        if(format != GL11.GL_RGBA && format != 0x80E1)
+            return;
 
         int texId = GlWmState.textureSlots.get(GlWmState.activeTexture);
         GlWmState.WmTexture texture = GlWmState.generatedTextures.get(texId);
@@ -510,6 +516,21 @@ public class GlStateManagerMixin {
         int unpack_alignment = GlWmState.pixelStore.getOrDefault(GL30.GL_UNPACK_ALIGNMENT, 4);
 
         if(width + offsetX <= texture.width && height + offsetY <= texture.height) {
+            int[] pixel_array = new int[width*height];
+
+            long pixel_size = 4L; //TODO support more formats..?
+            for(int y = 0; y < height; y++) {
+                for(int x = 0; x < width; x++){
+                    int current_x = x + unpack_skip_pixels;
+                    int current_y = (y + unpack_skip_rows) * 
+                        (unpack_row_length > 0 ? unpack_row_length : width);
+                    
+                    //TODO row_byte_offset proper impl || let row_byte_offset = if pixel_size >= unpack_alignment
+                    long offset = (current_x + current_y) * pixel_size;
+                    pixel_array[x + y * width] = MemoryUtil.memGetInt(pixels+offset);
+                }
+            }
+            
              WgpuNative.subImage2D(
                  texId,
                  target,
@@ -520,7 +541,7 @@ public class GlStateManagerMixin {
                  height,
                  format,
                  type,
-                 pixels,
+                 pixel_array,
                  unpack_row_length,
                  unpack_skip_pixels,
                  unpack_skip_rows,

--- a/fabric/src/main/java/dev/birb/wgpu/rust/WgpuNative.java
+++ b/fabric/src/main/java/dev/birb/wgpu/rust/WgpuNative.java
@@ -79,7 +79,7 @@ public class WgpuNative {
 
     public static native void texImage2D(int textureId, int target, int level, int internalFormat, int width, int height, int border, int format, int _type, long pixels_ptr);
 
-    public static native void subImage2D(int texId, int target, int level, int offsetX, int offsetY, int width, int height, int format, int _type, long pixels, int unpack_pixel_skip_rows, int unpack_skip_pixels, int unpack_skip_rows, int unpack_alignment);
+    public static native void subImage2D(int texId, int target, int level, int offsetX, int offsetY, int width, int height, int format, int _type, int[] pixels, int unpack_pixel_skip_rows, int unpack_skip_pixels, int unpack_skip_rows, int unpack_alignment);
 
     public static native void submitCommands();
 


### PR DESCRIPTION
This pr fixes the segfault issue caused by clicking UI enough times. The array used to get the pixel data for the text kept on going out of bounds, so I redid the entire portion to make glTexSubImage a lot more aggressive with keeping everything in check and ensuring to grab exactly what it needs.

KNOWN ISSUES ->
> - Some textures, like the creative inventory, doesn't have the right texture for the button mapping.

Fixed.

> - Some small boxes (like checkboxes or title screen accessibility box) have a chance to have a corrupted texture, often from changing languages. This doesn't happen every time, however.

Fixed.

> - While the UI no longer segfaults, there's a chance that the game can segfault when it first loads. This is high priority before the merge of the pr.

Fixed.

> STILL NEEDS TESTING! There's currently few guarantees in place to ensure the ptr doesn't read invalid data. This needs to be addressed before it's stable.

All segfaults from text appear to be fixed.

**Caveats**
Text can sometimes take a couple seconds to appear. This issue isn't critical and will be worked on in the future.