### PR TITLE
Make the Fabric project generate IDE run configs

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -9,6 +9,11 @@ base {
 
 loom {
     accessWidenerPath.set(file("src/main/resources/wgpu_mc.accesswidener"))
+    runs {
+        configureEach {
+            this.isIdeConfigGenerated = true
+        }
+    }
 }
 
 val modVersion: String by project


### PR DESCRIPTION
by default, loom does not generate IDE run configs for gradle subprojects. This simple fix forces it to make IDE run configs for the Electrum loom project