### PR TITLE
add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+watch_file flake.nix

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ classes/
 target/
 
 *.log
+
+# direnv
+.direnv/
+
+# nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699963925,
+        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "path": "/nix/store/hw0mp7awqma06m6s2h9yckyccxb63nqx-source",
+        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700273673,
+        "narHash": "sha256-0XD4JvrQiZ9BDFdH3VTwqZVXTYzOfS7DVblvqHBnWgE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "616074a1b2a71bbe44da4cc29a64255aecb8d541",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-parts,
+    rust-overlay,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+      perSystem = {
+        lib,
+        pkgs,
+        system,
+        ...
+      }: {
+        _module.args.pkgs = import nixpkgs {
+          inherit system;
+          overlays = [(import rust-overlay)];
+        };
+
+        # TODO: maybe add proper nix package derivations, to have patchelf-ed versions of the mod?
+        devShells.default = pkgs.mkShell {
+          # needed to compile and run stuff correctly
+          LD_LIBRARY_PATH = with pkgs;
+            lib.makeLibraryPath [
+              openssl
+              glfw
+              xorg.libX11
+            ];
+
+          buildInputs = with pkgs; [
+            # TODO: use rust-toolchain.toml to pinpoint nightly version to avoid breakage
+            (rust-bin.nightly.latest.default.override {
+              extensions = ["rust-analyzer" "rust-src"];
+            })
+
+            openssl
+            pkg-config
+
+            jdk17
+          ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
This PR adds a nix flake, which allows to have a proper development environment for nix/nixos users; this could also be used in the future for reproducible builds.
