### PR TITLE
Fix window resize causing game to freeze

### DIFF
--- a/rust/wgpu-mc-jni/src/lib.rs
+++ b/rust/wgpu-mc-jni/src/lib.rs
@@ -623,7 +623,7 @@ pub fn render(_env: JNIEnv, _class: JClass, _tick_delta: jfloat, _start_time: jl
             let size = wm.display.size.read();
             surface_config.width = size.width;
             surface_config.height = size.height;
-
+            SCENE.resize_depth_texture(wm, size.width, size.height);
             wm.display
                 .surface
                 .configure(&wm.display.device, &surface_config);

--- a/rust/wgpu-mc/src/mc/mod.rs
+++ b/rust/wgpu-mc/src/mc/mod.rs
@@ -196,7 +196,7 @@ pub struct Scene {
     pub stars_length: u32,
     pub render_effects: RenderEffectsData,
 
-    pub depth_texture: wgpu::Texture,
+    pub depth_texture: RwLock<wgpu::Texture>,
 }
 
 impl Scene {
@@ -228,17 +228,39 @@ impl Scene {
             stars_vertex_buffer: None,
             stars_length: 0,
             render_effects: Default::default(),
-            depth_texture: wm.display.device.create_texture(&wgpu::TextureDescriptor {
-                label: None,
-                size: framebuffer_size,
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: wgpu::TextureFormat::Depth32Float,
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                view_formats: &[],
-            }),
+            depth_texture: wm
+                .display
+                .device
+                .create_texture(&wgpu::TextureDescriptor {
+                    label: None,
+                    size: framebuffer_size,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Depth32Float,
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    view_formats: &[],
+                })
+                .into(),
         }
+    }
+
+    pub fn resize_depth_texture(&self, wm: &WmRenderer, width: u32, height: u32) {
+        self.depth_texture.read().destroy();
+        *self.depth_texture.write() = wm.display.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
     }
 }
 

--- a/rust/wgpu-mc/src/render/graph.rs
+++ b/rust/wgpu-mc/src/render/graph.rs
@@ -494,7 +494,7 @@ impl RenderGraph {
 
                     let depth_view =
                         if depth_texture == "@texture_depth" {
-                            arena.alloc(scene.depth_texture.create_view(
+                            arena.alloc(scene.depth_texture.read().create_view(
                                 &wgpu::TextureViewDescriptor {
                                     label: None,
                                     format: Some(wgpu::TextureFormat::Depth32Float),


### PR DESCRIPTION
The depth texture wasn't being resized, causing the rendering to throw an error and lock up. Did a sorta hacky way to resize it, but should be reliable.